### PR TITLE
fix(Download): Fix download and extract for Linux

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -10,14 +10,24 @@ source "${plugin_dir}/lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"
 
-# TODO: Adapt this to proper extension and adapt extracting strategy.
-release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
+if [ "$platform" == "darwin" ]; then
+    release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.zip"
+elif [ "$platform" == "linux" ]; then
+    release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
+else
+    fail "Unknown platform: ${platform}"
+fi
 
-# Download tar.gz file to the download directory
+# Download release file to the download directory
 download_release "$ASDF_INSTALL_VERSION" "$release_file"
 
-#  Extract contents of tar.gz file into the download directory
-tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "Could not extract $release_file"
+if [ "$platform" == "darwin" ]; then
+    unzip "$release_file" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+elif [ "$platform" == "linux" ]; then
+    tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+else
+    fail "Unknown platform: ${platform}"
+fi
 
-# Remove the tar.gz file since we don't need to keep it
+# Remove the release file since we don't need to keep it
 rm "$release_file"


### PR DESCRIPTION
This removes `--strip-components=1` when extracting the `tar.gz` which fixes installs on Linux. Tested with v4.1.1 and v3.4.4 (not all releases have binaries it seems) e.g. 

```
asdf plugin test podman https://github.com/nokome/asdf-podman.git "podman --version"
Updating podman to master
fatal: couldn't find remote ref master
fatal: Needed a single revision
error: pathspec 'master' did not match any file(s) known to git
* Downloading podman release 4.1.1...
podman version 4.1.1
```

Also fixes the `release_file` path and extract method for MacOS but the download URL looks wrong and I haven't tested at all.