### PR TITLE
Fix download, Fix darwin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 
 [podman](https://docs.podman.io/en/latest/) plugin for the [asdf version manager](https://asdf-vm.com).
 
-> NOTE: Due to how containers/podman distributes releases, this does not currently work for Linux.
-
 </div>
 
 # Contents


### PR DESCRIPTION
The download step was previously broken as podman now uses a different naming scheme for release archives that contains a trailing string for the architecture in the filenames `*_<ARCH>.*`, this is now fixed by detecting the architecture and using it in the filename.

The install step was broken for darwin as the podman release archive has changed folders structure for the position of the binary, this is now fixed by taking that into account.